### PR TITLE
[Chore] - #4 Activity View Controller 설정+띄워주는 메서드를 구현

### DIFF
--- a/MemoProject.xcodeproj/project.pbxproj
+++ b/MemoProject.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		A2B301A928C0F68E00D020B2 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = A2B301A828C0F68E00D020B2 /* Then */; };
 		A2B301AC28C0F71500D020B2 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = A2B301AB28C0F71500D020B2 /* Realm */; };
 		A2B301AE28C0F71500D020B2 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A2B301AD28C0F71500D020B2 /* RealmSwift */; };
+		A2B301C228C2095700D020B2 /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B301C128C2095700D020B2 /* UIViewController+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -30,6 +31,7 @@
 		A2B3019428C0594900D020B2 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		A2B3019628C0594900D020B2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A2B3019C28C0596D00D020B2 /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
+		A2B301C128C2095700D020B2 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIViewController+Extension.swift"; path = "MemoProject/Global/UIViewController+Extension.swift"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -116,6 +118,7 @@
 		A2B301B628C1D84100D020B2 /* Protocols */ = {
 			isa = PBXGroup;
 			children = (
+				A2B301C128C2095700D020B2 /* UIViewController+Extension.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -241,6 +244,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A2B301C228C2095700D020B2 /* UIViewController+Extension.swift in Sources */,
 				A2B3018D28C0594700D020B2 /* ViewController.swift in Sources */,
 				A2B3018928C0594700D020B2 /* AppDelegate.swift in Sources */,
 				A2B3018B28C0594700D020B2 /* SceneDelegate.swift in Sources */,

--- a/MemoProject/Global/UIViewController+Extension.swift
+++ b/MemoProject/Global/UIViewController+Extension.swift
@@ -1,0 +1,22 @@
+//
+//  UIViewController+Extension.swift
+//  MemoProject
+//
+//  Created by Doy Kim on 2022/09/02.
+//
+
+import Foundation
+import UIKit
+
+extension UIViewController {
+    /// Activity View Controller
+    public func showActivityViewController(text: String) {
+        
+        let viewController = UIActivityViewController(activityItems: [text], applicationActivities: nil)
+        
+        viewController.excludedActivityTypes = [ .assignToContact, .postToTencentWeibo, .postToVimeo, .postToFlickr, .saveToCameraRoll]
+        
+        self.present(viewController, animated: true)
+        
+    }
+}


### PR DESCRIPTION
##  *PULL REQUEST*

### 🎋 **Working Branch**
- chore/#4

### 💡 **Motivation**
- 메모 작성/수정 화면에서 공유버튼을 누르면 보이는 액티비티 뷰 컨트롤러를 설정했습니다. 
- 제외되는 리스트 : 연락처, 웨이보, 비메오, 플릭커, 카메라롤에 저장 

### 🔑 **Key Changes**
- 메모 작성/수정 화면에서 공유버튼을 누르면 보이는 Activity View Controller에 관련된 메서드를 UIViewController 의 익스텐션에서 정의하였습니다. 



### Relevant
- #4 
