### PR TITLE
[Chore] - #6 SceneDelegate에서 앱 실행 시 바로 보여지는 VC 구현

### DIFF
--- a/MemoProject/Application/SceneDelegate.swift
+++ b/MemoProject/Application/SceneDelegate.swift
@@ -16,7 +16,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let _ = (scene as? UIWindowScene) else { return }
+        
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+        let rootViewController = ViewController()
+        
+        let window = UIWindow(windowScene: windowScene)
+        window.rootViewController = rootViewController
+        self.window = window
+        window.makeKeyAndVisible()
+        
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {


### PR DESCRIPTION
##  *PULL REQUEST*

### 🎋 **Working Branch**
- chore/#6

### 💡 **Motivation**
- 앱에서 첫 실행되는 뷰를 코드로 구현합니다.

### 🔑 **Key Changes**
- SceneDelegate에 첫실행되는 뷰 컨트롤러의 클래스를 윈도우 루트뷰로 지정 

### Relevant Issue
- #6 
