### PR TITLE
[Refactor] - #10 BaseView와 BaseViewController 를 구성 후 ListVC에 적용

### DIFF
--- a/MemoProject.xcodeproj/project.pbxproj
+++ b/MemoProject.xcodeproj/project.pbxproj
@@ -20,6 +20,9 @@
 		A2B301AE28C0F71500D020B2 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A2B301AD28C0F71500D020B2 /* RealmSwift */; };
 		A2B301C228C2095700D020B2 /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B301C128C2095700D020B2 /* UIViewController+Extension.swift */; };
 		A2B301C928C212F900D020B2 /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B301C828C212F900D020B2 /* ListViewController.swift */; };
+		A2B301CD28C31D9400D020B2 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B301CC28C31D9400D020B2 /* BaseViewController.swift */; };
+		A2B301CF28C31F1400D020B2 /* ListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B301CE28C31F1400D020B2 /* ListView.swift */; };
+		A2B301D128C31F4400D020B2 /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B301D028C31F4400D020B2 /* BaseView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +37,9 @@
 		A2B3019C28C0596D00D020B2 /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
 		A2B301C128C2095700D020B2 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIViewController+Extension.swift"; path = "MemoProject/Global/UIViewController+Extension.swift"; sourceTree = SOURCE_ROOT; };
 		A2B301C828C212F900D020B2 /* ListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
+		A2B301CC28C31D9400D020B2 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
+		A2B301CE28C31F1400D020B2 /* ListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListView.swift; sourceTree = "<group>"; };
+		A2B301D028C31F4400D020B2 /* BaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -78,6 +84,7 @@
 				A2B3018C28C0594700D020B2 /* ViewController.swift */,
 				A2B3018E28C0594700D020B2 /* Main.storyboard */,
 				A2B3019628C0594900D020B2 /* Info.plist */,
+				A2B301CB28C31D6B00D020B2 /* Utility */,
 			);
 			path = MemoProject;
 			sourceTree = "<group>";
@@ -168,8 +175,18 @@
 			isa = PBXGroup;
 			children = (
 				A2B301C828C212F900D020B2 /* ListViewController.swift */,
+				A2B301CE28C31F1400D020B2 /* ListView.swift */,
 			);
 			path = List;
+			sourceTree = "<group>";
+		};
+		A2B301CB28C31D6B00D020B2 /* Utility */ = {
+			isa = PBXGroup;
+			children = (
+				A2B301CC28C31D9400D020B2 /* BaseViewController.swift */,
+				A2B301D028C31F4400D020B2 /* BaseView.swift */,
+			);
+			path = Utility;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -258,8 +275,11 @@
 				A2B301C228C2095700D020B2 /* UIViewController+Extension.swift in Sources */,
 				A2B3018D28C0594700D020B2 /* ViewController.swift in Sources */,
 				A2B3018928C0594700D020B2 /* AppDelegate.swift in Sources */,
+				A2B301CF28C31F1400D020B2 /* ListView.swift in Sources */,
 				A2B301C928C212F900D020B2 /* ListViewController.swift in Sources */,
 				A2B3018B28C0594700D020B2 /* SceneDelegate.swift in Sources */,
+				A2B301CD28C31D9400D020B2 /* BaseViewController.swift in Sources */,
+				A2B301D128C31F4400D020B2 /* BaseView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MemoProject/Presentation/List/ListView.swift
+++ b/MemoProject/Presentation/List/ListView.swift
@@ -1,0 +1,29 @@
+//
+//  ListView.swift
+//  MemoProject
+//
+//  Created by Doy Kim on 2022/09/03.
+//
+
+import UIKit
+
+class ListView: BaseView {
+    // MARK: - Properties
+    lazy var tableView = UITableView(frame: .init(), style: .insetGrouped).then {
+        $0.contentInset = UIEdgeInsets(top: 20, left: 0, bottom: 20, right: 0)
+    }
+
+    override func setupUI() {
+        /// View
+        
+        self.addSubview(tableView)
+    }
+    
+    override func setConstraints() {
+        tableView.snp.makeConstraints { make in
+            make.edges.equalTo(self.safeAreaLayoutGuide)
+        }
+    }
+    
+
+}

--- a/MemoProject/Presentation/List/ListViewController.swift
+++ b/MemoProject/Presentation/List/ListViewController.swift
@@ -9,38 +9,33 @@ import UIKit
 import SnapKit
 import Then
 
-class ListViewController: UIViewController {
+class ListViewController: BaseViewController {
     // MARK: - Properties
-    lazy var tableView = UITableView(frame: .init(), style: .insetGrouped).then {
-        $0.delegate = self
-        $0.dataSource = self
-        $0.contentInset = UIEdgeInsets(top: 20, left: 0, bottom: 20, right: 0)
-        
+    
+    let mainView = ListView()
+    
+    // MARK: - Lifecycle
+    override func loadView() {
+        self.view = mainView
     }
     
-
-    // MARK: - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        setupUI()
-        setupNavigationBar()
-        setConstraints()
-        
+                
 
     }
     // MARK: - Actions
     
     
     // MARK: - Helpers
-    func setupUI() {
-        /// View
-        self.view.backgroundColor = .systemBackground
-        
-        view.addSubview(tableView)
+    
+    override func configure() {
+        mainView.tableView.delegate = self
+        mainView.tableView.dataSource = self
     }
     
-    func setupNavigationBar() {
+    
+    override func setNavigationBar() {
         /// Bar Appearances
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()
@@ -50,7 +45,6 @@ class ListViewController: UIViewController {
         
         
         /// Navigation Item
-
         /// - Title
         self.navigationItem.title = "0개의 메모"
         /// -- 타이틀을 크게 설정
@@ -68,6 +62,7 @@ class ListViewController: UIViewController {
         
         /// - Toolbar
         self.navigationController?.isToolbarHidden = false
+        self.navigationController?.toolbar.backgroundColor = .systemBackground
         let makeMemoButton = UIBarButtonItem(barButtonSystemItem: .compose, target: self, action: nil)
         makeMemoButton.tintColor = .systemOrange
         let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil)
@@ -75,11 +70,6 @@ class ListViewController: UIViewController {
     
     }
     
-    func setConstraints() {
-        tableView.snp.makeConstraints { make in
-            make.edges.equalTo(view.safeAreaLayoutGuide)
-        }
-    }
 }
 
 // MARK: - Table View

--- a/MemoProject/Utility/BaseView.swift
+++ b/MemoProject/Utility/BaseView.swift
@@ -1,0 +1,30 @@
+//
+//  BaseView.swift
+//  MemoProject
+//
+//  Created by Doy Kim on 2022/09/03.
+//
+
+import UIKit
+
+class BaseView: UIView {
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.backgroundColor = .systemBackground
+        
+        setupUI()
+        setConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+    
+    func setupUI() {
+        
+    }
+    
+    func setConstraints() {}
+
+}

--- a/MemoProject/Utility/BaseViewController.swift
+++ b/MemoProject/Utility/BaseViewController.swift
@@ -1,0 +1,25 @@
+//
+//  BaseViewController.swift
+//  MemoProject
+//
+//  Created by Doy Kim on 2022/09/03.
+//
+
+import UIKit
+
+class BaseViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.view.backgroundColor = .systemBackground
+        configure()
+        setNavigationBar()
+
+    }
+    
+    func configure() { }
+    func setNavigationBar() { }
+
+    
+}


### PR DESCRIPTION
##  *PULL REQUEST*

### 🎋 **Working Branch**
- refactor/#10

### 💡 **Motivation**
- Base View와 Base View Controller를 이용해 실제 VC에서 자주 사용하는 형태를 유지하고, UI에 관련된 내용을 다른 곳에서 관리하여 VC에서는 액션에 대한 컨트롤만 다룰 수 있게 한다.

### 🔑 **Key Changes**
- Base View와 Base View Controller 선언
- Base View를 상속받는 List View 만들기
- List View Controller의 메인 뷰를 List View로 변경



### Relevant
- #10 
