### PR TITLE
[Design] - #13 메모 작성/수정 화면 디자인

### DIFF
--- a/MemoProject.xcodeproj/project.pbxproj
+++ b/MemoProject.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		A2B301D128C31F4400D020B2 /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B301D028C31F4400D020B2 /* BaseView.swift */; };
 		A2F1D9BE28C368C100C3B010 /* Memo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2F1D9BD28C368C100C3B010 /* Memo.swift */; };
 		A2F1D9C028C36BCA00C3B010 /* MemoRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2F1D9BF28C36BCA00C3B010 /* MemoRepository.swift */; };
+		A2F1D9C828C3748C00C3B010 /* WriteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2F1D9C728C3748C00C3B010 /* WriteView.swift */; };
+		A2F1D9CA28C3749E00C3B010 /* WriteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2F1D9C928C3749E00C3B010 /* WriteViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -44,6 +46,8 @@
 		A2B301D028C31F4400D020B2 /* BaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
 		A2F1D9BD28C368C100C3B010 /* Memo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Memo.swift; sourceTree = "<group>"; };
 		A2F1D9BF28C36BCA00C3B010 /* MemoRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoRepository.swift; sourceTree = "<group>"; };
+		A2F1D9C728C3748C00C3B010 /* WriteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteView.swift; sourceTree = "<group>"; };
+		A2F1D9C928C3749E00C3B010 /* WriteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -163,6 +167,7 @@
 			isa = PBXGroup;
 			children = (
 				A2F1D9BC28C3684600C3B010 /* Main(disused) */,
+				A2F1D9C428C3746100C3B010 /* Write */,
 				A2B301C728C212EF00D020B2 /* List */,
 			);
 			path = Presentation;
@@ -225,6 +230,15 @@
 				A2B3018E28C0594700D020B2 /* Main.storyboard */,
 			);
 			path = "Main(disused)";
+			sourceTree = "<group>";
+		};
+		A2F1D9C428C3746100C3B010 /* Write */ = {
+			isa = PBXGroup;
+			children = (
+				A2F1D9C928C3749E00C3B010 /* WriteViewController.swift */,
+				A2F1D9C728C3748C00C3B010 /* WriteView.swift */,
+			);
+			path = Write;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -315,6 +329,8 @@
 				A2B3018928C0594700D020B2 /* AppDelegate.swift in Sources */,
 				A2F1D9C028C36BCA00C3B010 /* MemoRepository.swift in Sources */,
 				A2B301CF28C31F1400D020B2 /* ListView.swift in Sources */,
+				A2F1D9C828C3748C00C3B010 /* WriteView.swift in Sources */,
+				A2F1D9CA28C3749E00C3B010 /* WriteViewController.swift in Sources */,
 				A2B301C928C212F900D020B2 /* ListViewController.swift in Sources */,
 				A2B3018B28C0594700D020B2 /* SceneDelegate.swift in Sources */,
 				A2F1D9BE28C368C100C3B010 /* Memo.swift in Sources */,

--- a/MemoProject/Application/SceneDelegate.swift
+++ b/MemoProject/Application/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         
         guard let windowScene = (scene as? UIWindowScene) else { return }
-        let vc = ListViewController()
+        let vc = WriteViewController() // 여기서 변경
         let rootViewController = UINavigationController(rootViewController: vc)
         let window = UIWindow(windowScene: windowScene)
         window.rootViewController = rootViewController

--- a/MemoProject/Presentation/List/ListViewController.swift
+++ b/MemoProject/Presentation/List/ListViewController.swift
@@ -36,14 +36,7 @@ class ListViewController: BaseViewController {
     
     
     override func setNavigationBar() {
-        /// Bar Appearances
-        let appearance = UINavigationBarAppearance()
-        appearance.configureWithOpaqueBackground()
-        appearance.backgroundColor = .systemGray6
-        self.navigationItem.standardAppearance = appearance
-        self.navigationItem.scrollEdgeAppearance = appearance
-        
-        
+        super.setNavigationBar()
         /// Navigation Item
         /// - Title
         self.navigationItem.title = "0개의 메모"

--- a/MemoProject/Presentation/Write/WriteView.swift
+++ b/MemoProject/Presentation/Write/WriteView.swift
@@ -1,0 +1,34 @@
+//
+//  WriteView.swift
+//  MemoProject
+//
+//  Created by Doy Kim on 2022/09/03.
+//
+
+import UIKit
+import Then
+import SnapKit
+
+
+class WriteView: BaseView {
+    
+    // MARK: - Properties
+    private lazy var textView = UITextView().then {
+        $0.becomeFirstResponder()
+        $0.textContainerInset = UIEdgeInsets(top: 24, left: 20, bottom: 20, right: 20)
+        $0.font = .boldSystemFont(ofSize: 14)
+    }
+
+    // MARK: - UI
+    override func setupUI() {
+        self.addSubview(textView)
+    }
+    
+    override func setConstraints() {
+        textView.snp.makeConstraints { make in
+            make.edges.equalTo(self.safeAreaLayoutGuide)
+        }
+    }
+    
+
+}

--- a/MemoProject/Presentation/Write/WriteViewController.swift
+++ b/MemoProject/Presentation/Write/WriteViewController.swift
@@ -1,0 +1,43 @@
+//
+//  WriteViewController.swift
+//  MemoProject
+//
+//  Created by Doy Kim on 2022/09/03.
+//
+
+import UIKit
+
+class WriteViewController: BaseViewController {
+    // MARK: - Properties
+    
+    let mainView = WriteView()
+    
+    // MARK: - Lifecycle
+    override func loadView() {
+        self.view = mainView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+    }
+
+    // MARK: - Helpers
+    override func configure() {
+        //mainView.textView.delegate = self
+    }
+    
+    override func setNavigationBar() {
+        super.setNavigationBar()
+        /// Navigation Item
+        /// - Right Bar Button Item
+        let shareButton = UIBarButtonItem(image: UIImage(systemName: "square.and.arrow.up"), style: .plain, target: self, action: nil)
+        let finishButton = UIBarButtonItem(title: "완료", style: .plain, target: self, action: nil)
+        
+        let items = [ finishButton, shareButton  ]
+        items.forEach { $0.tintColor = .systemOrange }
+        
+        navigationItem.rightBarButtonItems = items
+        
+    }
+}

--- a/MemoProject/Utility/BaseViewController.swift
+++ b/MemoProject/Utility/BaseViewController.swift
@@ -19,7 +19,14 @@ class BaseViewController: UIViewController {
     }
     
     func configure() { }
-    func setNavigationBar() { }
+    func setNavigationBar() {
+        /// Bar Appearances
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = .systemGray6
+        self.navigationItem.standardAppearance = appearance
+        self.navigationItem.scrollEdgeAppearance = appearance
+    }
 
     
 }


### PR DESCRIPTION
##  *PULL REQUEST*

### 🎋 **Working Branch**
- design/#13

### 💡 **Motivation**
메모 작성/수정 화면 디자인입니다.

### 🔑 **Key Changes**
- 네비게이션에 공유와 완료버튼이 들어갔습니다.
- 텍스트뷰에서 키보드가 바로 뜹니다. (`becomeFirstResponder()`)
- 텍스트뷰 상하좌우에 `textContainerInset` 이 있습니다. (상 24, 하좌우 20)
- 기본 폰트가 작아서, 14 bold 로 바꿔주었습니다.

### Relevant
- #13 
