### PR TITLE
[Fix] - #38 프로토콜 delegate에 약한 참조를 선언

### DIFF
--- a/MemoProject/Presentation/Write/WriteViewController.swift
+++ b/MemoProject/Presentation/Write/WriteViewController.swift
@@ -10,7 +10,7 @@ import RealmSwift
 
 class WriteViewController: BaseViewController {
     // MARK: - Properties
-    var delegate: MemoDelegate?
+    weak var delegate: MemoDelegate?
     var editingMode: Bool = false
     var editingMemo = Memo()
     let mainView = WriteView()


### PR DESCRIPTION
##  *PULL REQUEST*

### 🎋 **Working Branch**
- fix/#38

### 💡 **Motivation**
프로토콜을 약한참조 weak를 걸기 위해서는, 해당 커스텀 프로토콜에 참조타입만 가능하다는 AnyObject 프로토콜을 채택해주어야 한다. 이미 채택하였으므로 작성하기 화면에 선언해둔 delegate 프로토콜 변수에 약한 참조를 걸어준다.

### 🔑 **Key Changes**
- weak 키워드 추가 



### Relevant Issue(s)
- #38 
