### PR TITLE
[Fix] - #40 새로운 메모인지, 기존 메모를 선택하는지에 따라서 바버튼과 키보드가 보이거나 안보이도록 수정완료

### DIFF
--- a/MemoProject/Presentation/List/ListViewController.swift
+++ b/MemoProject/Presentation/List/ListViewController.swift
@@ -133,7 +133,8 @@ class ListViewController: BaseViewController {
     
     @objc func makeMemoButtonTapped(_ sender: UIBarButtonItem) {
         let vc = WriteViewController()
-        vc.isEditing = false
+        vc.isEditing = true
+        vc.editingMode = false // 새 메모라서 편집모드 X
         self.navigationController?.pushViewController(vc, animated: true)
         
     }
@@ -192,12 +193,12 @@ extension ListViewController: UITableViewDelegate, UITableViewDataSource {
 
         return cell
     }
-    /// 선택되었을 경우
+    /// 셀 선택되었을 경우
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let vc = WriteViewController()
         vc.delegate = self
-        vc.editingMode = true
-        
+        vc.isEditing = false
+        vc.editingMode = true // 기존메모 수정이므로 editingMode 는 참 
         if isSearching {
             self.navigationItem.backButtonTitle = "검색"
             let memo = filterResult[indexPath.row]

--- a/MemoProject/Presentation/Write/WriteView.swift
+++ b/MemoProject/Presentation/Write/WriteView.swift
@@ -14,7 +14,6 @@ class WriteView: BaseView {
     
     // MARK: - Properties
     public lazy var textView = UITextView().then {
-        $0.becomeFirstResponder()
         $0.textContainerInset = UIEdgeInsets(top: 24, left: 20, bottom: 20, right: 20)
         $0.font = .boldSystemFont(ofSize: 14)
     }

--- a/MemoProject/Presentation/Write/WriteViewController.swift
+++ b/MemoProject/Presentation/Write/WriteViewController.swift
@@ -23,10 +23,9 @@ class WriteViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        
                 
     }
+    
     override func viewWillAppear(_ animated: Bool) {
          super.viewWillAppear(animated)
         
@@ -39,7 +38,12 @@ class WriteViewController: BaseViewController {
 
     // MARK: - Helpers
     override func configure() {
-        setBarButton(false)
+        /// 기존 메모 선택해서 들어왔을 경우 바버튼을 숨긴다
+        if editingMode {
+            setBarButton(false)
+        } else {
+            setBarButton(true)
+        }
         mainView.textView.delegate = self
         
     }
@@ -69,14 +73,15 @@ class WriteViewController: BaseViewController {
             let title = String(text[..<index])
             let content = String(text[index...])
             let item = Memo(title: title, content: content, dateCreated: Date())
-            if editingMode {
+            
+            if editingMode { /// - 메모 편집할 때
                 delegate?.updateMemo2(title: title, content: content, dateCreated: Date(), _id: editingMemo._id)
             }
             else {
                 repository.createMemo(item)
             }
             
-        } else {
+        } else { /// - 새 메모 만들 때
             let item = Memo(title: text, content: nil, dateCreated: Date())
             if editingMode {
                 delegate?.updateMemo2(title: text, content: nil, dateCreated: Date(), _id: editingMemo._id)
@@ -104,6 +109,9 @@ class WriteViewController: BaseViewController {
     func setBarButton(_ bool : Bool) {
         /// - Right Bar Button Item
         if bool {
+            /// - 키보드도 올라오게 해준다. 
+            mainView.textView.becomeFirstResponder()
+            
             let shareButton = UIBarButtonItem(image: UIImage(systemName: "square.and.arrow.up"), style: .plain, target: self, action: #selector(shareButtonTapped))
             let finishButton = UIBarButtonItem(title: "완료", style: .plain, target: self, action: #selector(finishButtonTapped))
             
@@ -122,5 +130,6 @@ class WriteViewController: BaseViewController {
 extension WriteViewController: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
         setBarButton(true)
+        
     }
 }


### PR DESCRIPTION
##  *PULL REQUEST*

### 🎋 **Working Branch**
- fix/#40

### 💡 **Motivation**
바버튼을 숨기는 메서드를 만들었지만, 화면전환 할 때 제대로 해주지 않은 부분을 수정하였다.

### 🔑 **Key Changes**
- 기존 메모인지 새 메모인지를 구분하는 `isEditing`을 화면전환 시 제대로 설정해주지 못한 걸 수정
- 텍스트뷰의 `.becomeFirstResponder()`를 바버튼이 보일 경우 보이도록 같은 메서드에 넣어줌 


### Relevant Issue(s)
- #40 
