### PR TITLE
[Fix] - #21 리스트에서 다른 화면으로 갈 때 네비게이션 바가 커지는 부분 수정

### DIFF
--- a/MemoProject.xcodeproj/project.pbxproj
+++ b/MemoProject.xcodeproj/project.pbxproj
@@ -517,6 +517,7 @@
 				DEVELOPMENT_TEAM = F7B353LPM3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MemoProject/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "김도이";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
@@ -547,6 +548,7 @@
 				DEVELOPMENT_TEAM = F7B353LPM3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MemoProject/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "김도이";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;

--- a/MemoProject/Presentation/List/ListViewController.swift
+++ b/MemoProject/Presentation/List/ListViewController.swift
@@ -85,9 +85,10 @@ class ListViewController: BaseViewController {
     /// 네비게이션 바의 사이즈가 줄어들지 않는 부분을 수정
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        self.navigationController?.navigationBar.prefersLargeTitles = false
         /// 네비게이션 타이틀이 뷰가 전환될 때 잔상으로 남는 부분을 수정
         self.navigationItem.title = nil
+        
+        
     }
     
     

--- a/MemoProject/Presentation/List/ListViewController.swift
+++ b/MemoProject/Presentation/List/ListViewController.swift
@@ -86,6 +86,8 @@ class ListViewController: BaseViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         self.navigationController?.navigationBar.prefersLargeTitles = false
+        /// 네비게이션 타이틀이 뷰가 전환될 때 잔상으로 남는 부분을 수정
+        self.navigationItem.title = nil
     }
     
     

--- a/MemoProject/Presentation/List/ListViewController.swift
+++ b/MemoProject/Presentation/List/ListViewController.swift
@@ -68,6 +68,8 @@ class ListViewController: BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         fetchRealm()
+        /// 다른 화면에 갔다가 다시 돌아올 경우 네비게이션 타이틀이 줄어드는 부분을 수정
+        self.navigationController?.navigationBar.prefersLargeTitles = true
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -78,6 +80,12 @@ class ListViewController: BaseViewController {
         /// Walkthrough 팝업 띄우기
         showWalkthroughPopup()
            
+    }
+    
+    /// 네비게이션 바의 사이즈가 줄어들지 않는 부분을 수정
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.navigationController?.navigationBar.prefersLargeTitles = false
     }
     
     

--- a/MemoProject/Presentation/Write/WriteViewController.swift
+++ b/MemoProject/Presentation/Write/WriteViewController.swift
@@ -47,6 +47,7 @@ class WriteViewController: BaseViewController {
     override func setNavigationBar() {
         super.setNavigationBar()
         /// Navigation Item
+        self.navigationController?.navigationBar.prefersLargeTitles = false
     }
     
     // MARK: - Actions


### PR DESCRIPTION
##  *PULL REQUEST*
리스트에서 다른 화면으로 갈 때 네비게이션 바가 커지는 부분 수정

### 🎋 **Working Branch**
- fix/#21

### 💡 **Motivation**
메모 리스트에서 작성하기, 수정하기로 넘어갈 경우 네비게이션 바의 크기가 변하지 않고 남아 미관상 좋지 않은 부분을 수정 
helped by @GoForWalk

### 🔑 **Key Changes**
1. 작성하기 뷰에서  `self.navigationController?.navigationBar.prefersLargeTitles = false` 를 설정
2. 홈화면으로 다시 돌아오는 `viewWillAppear(:)` 에서 다시` .presfersLargeTitles` 를 `true`로 바꿔줌



🏞 **Screenshots**
|Feature|Screenshot|
|:--:|:--:|
| 네비게이션 바가 이제 깔끔해졌다. |   ![ezgif-1-4ad9f1e14b](https://user-images.githubusercontent.com/51395335/189515378-96452a70-4662-4b2e-9197-7019b47ccf01.gif) |

### Relevant Issue(s)
- #21
