### PR TITLE
[Design] #47 테이블 뷰를 컴포지셔널 레이아웃+DiffableDataSource의 콜렉션뷰로 만들기 

### DIFF
--- a/MemoProject.xcodeproj/project.pbxproj
+++ b/MemoProject.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		58B9377D586E9F84E0501283 /* Pods_MemoProject.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02856E0A185570F61349B69B /* Pods_MemoProject.framework */; };
+		A2B2F33A2900A266001112CF /* CompListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B2F3392900A266001112CF /* CompListViewController.swift */; };
 		A2B3018928C0594700D020B2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3018828C0594700D020B2 /* AppDelegate.swift */; };
 		A2B3018B28C0594700D020B2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3018A28C0594700D020B2 /* SceneDelegate.swift */; };
 		A2B3018D28C0594700D020B2 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3018C28C0594700D020B2 /* ViewController.swift */; };
@@ -37,6 +38,7 @@
 /* Begin PBXFileReference section */
 		02856E0A185570F61349B69B /* Pods_MemoProject.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MemoProject.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		930A9A460249834034C5BE19 /* Pods-MemoProject.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MemoProject.debug.xcconfig"; path = "Target Support Files/Pods-MemoProject/Pods-MemoProject.debug.xcconfig"; sourceTree = "<group>"; };
+		A2B2F3392900A266001112CF /* CompListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompListViewController.swift; sourceTree = "<group>"; };
 		A2B3018528C0594700D020B2 /* MemoProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MemoProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A2B3018828C0594700D020B2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A2B3018A28C0594700D020B2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -213,6 +215,7 @@
 			children = (
 				A2B301C828C212F900D020B2 /* ListViewController.swift */,
 				A2B301CE28C31F1400D020B2 /* ListView.swift */,
+				A2B2F3392900A266001112CF /* CompListViewController.swift */,
 			);
 			path = List;
 			sourceTree = "<group>";
@@ -290,7 +293,6 @@
 				930A9A460249834034C5BE19 /* Pods-MemoProject.debug.xcconfig */,
 				FCA89A43FDA1AEE70265714F /* Pods-MemoProject.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -349,7 +351,7 @@
 			packageReferences = (
 				A2B301A428C0F67C00D020B2 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				A2B301A728C0F68E00D020B2 /* XCRemoteSwiftPackageReference "Then" */,
-				A2B301AA28C0F71500D020B2 /* XCRemoteSwiftPackageReference "realm-swift.git" */,
+				A2B301AA28C0F71500D020B2 /* XCRemoteSwiftPackageReference "realm-swift" */,
 			);
 			productRefGroup = A2B3018628C0594700D020B2 /* Products */;
 			projectDirPath = "";
@@ -429,6 +431,7 @@
 				A2B301CF28C31F1400D020B2 /* ListView.swift in Sources */,
 				A2F1D9C828C3748C00C3B010 /* WriteView.swift in Sources */,
 				A2F1D9D528C4DA1000C3B010 /* LandscapeManager.swift in Sources */,
+				A2B2F33A2900A266001112CF /* CompListViewController.swift in Sources */,
 				A2F1D9CA28C3749E00C3B010 /* WriteViewController.swift in Sources */,
 				A2B301C928C212F900D020B2 /* ListViewController.swift in Sources */,
 				A2F1D9D228C4CD7900C3B010 /* WalkthroughViewController.swift in Sources */,
@@ -594,7 +597,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -626,7 +629,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -680,7 +683,7 @@
 				minimumVersion = 3.0.0;
 			};
 		};
-		A2B301AA28C0F71500D020B2 /* XCRemoteSwiftPackageReference "realm-swift.git" */ = {
+		A2B301AA28C0F71500D020B2 /* XCRemoteSwiftPackageReference "realm-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/realm/realm-swift.git";
 			requirement = {
@@ -703,12 +706,12 @@
 		};
 		A2B301AB28C0F71500D020B2 /* Realm */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A2B301AA28C0F71500D020B2 /* XCRemoteSwiftPackageReference "realm-swift.git" */;
+			package = A2B301AA28C0F71500D020B2 /* XCRemoteSwiftPackageReference "realm-swift" */;
 			productName = Realm;
 		};
 		A2B301AD28C0F71500D020B2 /* RealmSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A2B301AA28C0F71500D020B2 /* XCRemoteSwiftPackageReference "realm-swift.git" */;
+			package = A2B301AA28C0F71500D020B2 /* XCRemoteSwiftPackageReference "realm-swift" */;
 			productName = RealmSwift;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/MemoProject.xcodeproj/project.pbxproj
+++ b/MemoProject.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		58B9377D586E9F84E0501283 /* Pods_MemoProject.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02856E0A185570F61349B69B /* Pods_MemoProject.framework */; };
 		A2B2F33A2900A266001112CF /* CompListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B2F3392900A266001112CF /* CompListViewController.swift */; };
+		A2B2F33C2900A446001112CF /* CompListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B2F33B2900A446001112CF /* CompListView.swift */; };
 		A2B3018928C0594700D020B2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3018828C0594700D020B2 /* AppDelegate.swift */; };
 		A2B3018B28C0594700D020B2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3018A28C0594700D020B2 /* SceneDelegate.swift */; };
 		A2B3018D28C0594700D020B2 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3018C28C0594700D020B2 /* ViewController.swift */; };
@@ -39,6 +40,7 @@
 		02856E0A185570F61349B69B /* Pods_MemoProject.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MemoProject.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		930A9A460249834034C5BE19 /* Pods-MemoProject.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MemoProject.debug.xcconfig"; path = "Target Support Files/Pods-MemoProject/Pods-MemoProject.debug.xcconfig"; sourceTree = "<group>"; };
 		A2B2F3392900A266001112CF /* CompListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompListViewController.swift; sourceTree = "<group>"; };
+		A2B2F33B2900A446001112CF /* CompListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompListView.swift; sourceTree = "<group>"; };
 		A2B3018528C0594700D020B2 /* MemoProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MemoProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A2B3018828C0594700D020B2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A2B3018A28C0594700D020B2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -216,6 +218,7 @@
 				A2B301C828C212F900D020B2 /* ListViewController.swift */,
 				A2B301CE28C31F1400D020B2 /* ListView.swift */,
 				A2B2F3392900A266001112CF /* CompListViewController.swift */,
+				A2B2F33B2900A446001112CF /* CompListView.swift */,
 			);
 			path = List;
 			sourceTree = "<group>";
@@ -426,6 +429,7 @@
 				A2B301C228C2095700D020B2 /* UIViewController+Extension.swift in Sources */,
 				A2F1D9CC28C4083A00C3B010 /* Date+Extension.swift in Sources */,
 				A2B3018D28C0594700D020B2 /* ViewController.swift in Sources */,
+				A2B2F33C2900A446001112CF /* CompListView.swift in Sources */,
 				A2B3018928C0594700D020B2 /* AppDelegate.swift in Sources */,
 				A2F1D9C028C36BCA00C3B010 /* MemoRepository.swift in Sources */,
 				A2B301CF28C31F1400D020B2 /* ListView.swift in Sources */,

--- a/MemoProject.xcodeproj/project.pbxproj
+++ b/MemoProject.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		58B9377D586E9F84E0501283 /* Pods_MemoProject.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02856E0A185570F61349B69B /* Pods_MemoProject.framework */; };
 		A2B2F33A2900A266001112CF /* CompListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B2F3392900A266001112CF /* CompListViewController.swift */; };
 		A2B2F33C2900A446001112CF /* CompListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B2F33B2900A446001112CF /* CompListView.swift */; };
+		A2B2F33E2900ACD9001112CF /* Results+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B2F33D2900ACD9001112CF /* Results+Extension.swift */; };
 		A2B3018928C0594700D020B2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3018828C0594700D020B2 /* AppDelegate.swift */; };
 		A2B3018B28C0594700D020B2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3018A28C0594700D020B2 /* SceneDelegate.swift */; };
 		A2B3018D28C0594700D020B2 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3018C28C0594700D020B2 /* ViewController.swift */; };
@@ -41,6 +42,7 @@
 		930A9A460249834034C5BE19 /* Pods-MemoProject.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MemoProject.debug.xcconfig"; path = "Target Support Files/Pods-MemoProject/Pods-MemoProject.debug.xcconfig"; sourceTree = "<group>"; };
 		A2B2F3392900A266001112CF /* CompListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompListViewController.swift; sourceTree = "<group>"; };
 		A2B2F33B2900A446001112CF /* CompListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompListView.swift; sourceTree = "<group>"; };
+		A2B2F33D2900ACD9001112CF /* Results+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Results+Extension.swift"; sourceTree = "<group>"; };
 		A2B3018528C0594700D020B2 /* MemoProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MemoProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A2B3018828C0594700D020B2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A2B3018A28C0594700D020B2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -151,6 +153,7 @@
 				A2B301C128C2095700D020B2 /* UIViewController+Extension.swift */,
 				A2F1D9CD28C4A79000C3B010 /* UILabel+Extension.swift */,
 				A2F1D9CB28C4083A00C3B010 /* Date+Extension.swift */,
+				A2B2F33D2900ACD9001112CF /* Results+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -441,6 +444,7 @@
 				A2F1D9D228C4CD7900C3B010 /* WalkthroughViewController.swift in Sources */,
 				A2B3018B28C0594700D020B2 /* SceneDelegate.swift in Sources */,
 				A2F1D9CE28C4A79000C3B010 /* UILabel+Extension.swift in Sources */,
+				A2B2F33E2900ACD9001112CF /* Results+Extension.swift in Sources */,
 				A2F1D9BE28C368C100C3B010 /* Memo.swift in Sources */,
 				A2B301CD28C31D9400D020B2 /* BaseViewController.swift in Sources */,
 				A2B301D128C31F4400D020B2 /* BaseView.swift in Sources */,

--- a/MemoProject/Application/SceneDelegate.swift
+++ b/MemoProject/Application/SceneDelegate.swift
@@ -20,7 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         
         guard let windowScene = (scene as? UIWindowScene) else { return }
-        let vc = ListViewController() // 여기서 변경
+        let vc = CompListViewController() // 여기서 변경
         let rootViewController = UINavigationController(rootViewController: vc)
         let window = UIWindow(windowScene: windowScene)
         window.rootViewController = rootViewController

--- a/MemoProject/Global/Extensions/Results+Extension.swift
+++ b/MemoProject/Global/Extensions/Results+Extension.swift
@@ -1,0 +1,17 @@
+//
+//  Results+Extension.swift
+//  MemoProject
+//
+//  Created by Doy Kim on 2022/10/20.
+//
+
+import Foundation
+import RealmSwift
+
+extension Results {
+  func toArray() -> [Element] {
+    return compactMap {
+        $0
+    }
+  }
+}

--- a/MemoProject/Presentation/List/CompListView.swift
+++ b/MemoProject/Presentation/List/CompListView.swift
@@ -1,0 +1,28 @@
+//
+//  CompListView.swift
+//  MemoProject
+//
+//  Created by Doy Kim on 2022/10/20.
+//
+
+import UIKit
+
+class CompListView: BaseView {
+    
+    lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout() ).then {
+        
+        $0.backgroundColor = .clear
+    }
+
+
+    override func setupUI() {
+        addSubview(collectionView)
+    }
+    
+    override func setConstraints() {
+        collectionView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+
+}

--- a/MemoProject/Presentation/List/CompListViewController.swift
+++ b/MemoProject/Presentation/List/CompListViewController.swift
@@ -1,0 +1,221 @@
+//
+//  CompListViewController.swift
+//  MemoProject
+//
+//  Created by Doy Kim on 2022/10/20.
+//
+
+import UIKit
+import SnapKit
+import Then
+import RealmSwift
+
+class CompListViewController: BaseViewController {
+    // MARK: - Properties
+    let mainView = CompListView()
+    let repository = MemoRepository()
+    
+    var query = String() // 검색어
+    var filterResult: Results<Memo>!
+    
+    let searchController = UISearchController(searchResultsController: nil)
+    
+    var isSearching: Bool {
+        get {
+            return searchController.isActive
+        }
+    }
+    
+    var list: Results<Memo>! {
+        didSet {
+            self.navigationItem.title = "\(numberFormat(for: list.count))개의 메모"
+            
+            self.configureDataSource()
+        }
+    }
+    
+    var pinList: Results<Memo>!
+    var unpinList: Results<Memo>!
+    
+    private var dataSource: UICollectionViewDiffableDataSource<Int, Memo>!
+    
+    // MARK: - Lifecycle
+    override func loadView() {
+        view = mainView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        fetchRealm()
+        /// 다른 화면에 갔다가 다시 돌아올 경우 네비게이션 타이틀이 줄어드는 부분을 수정
+        self.navigationController?.navigationBar.prefersLargeTitles = true
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        // 저장 후 돌아오는 시점
+        if repository.fetch() != list {
+            fetchRealm()
+        }
+        /// Walkthrough 팝업 띄우기
+        showWalkthroughPopup()
+        
+    }
+    
+    /// 네비게이션 바의 사이즈가 줄어들지 않는 부분을 수정
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        /// 네비게이션 타이틀이 뷰가 전환될 때 잔상으로 남는 부분을 수정
+        self.navigationItem.title = nil
+        
+        
+    }
+    override func configure() {
+        
+        //mainView.collectionView.delegate = self
+        mainView.collectionView.collectionViewLayout = createLayout()
+        configureDataSource()
+    }
+    
+    
+    override func setNavigationBar() {
+        super.setNavigationBar()
+        /// Navigation Item
+        /// - Title
+        self.navigationItem.backButtonTitle = "메모"
+        
+        /// -- 타이틀을 크게 설정
+        self.navigationController?.navigationBar.prefersLargeTitles = true
+        self.navigationItem.largeTitleDisplayMode = .always
+        
+        /// - Search Controller
+        searchController.searchBar.placeholder = "검색"
+        searchController.searchResultsUpdater = self
+        searchController.obscuresBackgroundDuringPresentation = false
+        // definesPresentationContext = true
+        
+        
+        navigationItem.searchController = searchController
+        /// -- 스크롤이 되더라도 검색바가 보이게 설정
+        navigationItem.hidesSearchBarWhenScrolling = false
+        
+        /// - Toolbar
+        self.navigationController?.isToolbarHidden = false
+        self.navigationController?.toolbar.backgroundColor = .systemBackground
+        let makeMemoButton = UIBarButtonItem(barButtonSystemItem: .compose, target: self, action: #selector(makeMemoButtonTapped))
+        makeMemoButton.tintColor = .systemOrange
+        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil)
+        self.toolbarItems = [flexibleSpace, makeMemoButton]
+    }
+    
+    // MARK: - Actions
+    func fetchRealm() {
+        list = repository.fetch() // 저장시점이랑 viewWillAppear 시점이 다르다.
+        pinList = repository.fetchPinnedMemo(true)
+        unpinList = repository.fetchPinnedMemo(false)
+    }
+    
+    @objc func makeMemoButtonTapped(_ sender: UIBarButtonItem) {
+        let vc = WriteViewController()
+        vc.isEditing = true
+        vc.editingMode = false // 새 메모라서 편집모드 X
+        self.navigationController?.pushViewController(vc, animated: true)
+    }
+}
+
+extension CompListViewController {
+    private func createLayout() -> UICollectionViewLayout {
+        
+        let config = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
+        let layout = UICollectionViewCompositionalLayout.list(using: config)
+        
+        return layout
+    }
+    
+    private func configureDataSource() {
+        
+        // Cell Registration
+        let cellRegistration =  UICollectionView.CellRegistration<UICollectionViewListCell, Memo>(handler: { cell, indexPath, itemIdentifier in
+            
+            var content = UIListContentConfiguration.valueCell()
+            
+            content.textProperties.font = .boldSystemFont(ofSize: 14)
+            content.secondaryTextProperties.font = .systemFont(ofSize: 12)
+            
+            content.text = itemIdentifier.title
+            
+            let dateString: String = self.dateFormat(for: itemIdentifier.dateCreated).replacingOccurrences(of: "\n", with: "")
+            
+            var contentString = ""
+            
+            if let content = itemIdentifier.content {
+                contentString = content.replacingOccurrences(of: "\n", with: "")
+            }
+                        
+            content.prefersSideBySideTextAndSecondaryText = false
+            content.secondaryText = "\(dateString)  \(contentString)"
+            
+            cell.contentConfiguration = content
+            
+            var background = UIBackgroundConfiguration.listPlainCell()
+            background.backgroundColor = .systemBackground
+            cell.backgroundConfiguration = background
+            
+        })
+        
+        // Diffable Data Source
+        // collectionView.dataSource = self 코드의 대체
+        // CellForItemAt 대체
+        dataSource = UICollectionViewDiffableDataSource(collectionView: mainView.collectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
+            
+            let cell = collectionView.dequeueConfiguredReusableCell(using: cellRegistration , for: indexPath, item: itemIdentifier)
+            
+            return cell
+        })
+        
+        // 스냅샷, 모델을 Initialise 해줄 것
+        // 스냅샷 타입은 위에 dataSource형태와 맞추기 (섹션Int, 모델타입)
+        var snapshot = NSDiffableDataSourceSnapshot<Int, Memo>()
+        snapshot.appendSections([0])
+        guard let list = list else { return }
+        
+        snapshot.appendItems(list.toArray())
+        dataSource.apply(snapshot)
+        
+    }
+    
+    
+}
+
+
+// MARK: - Search Bar Result Update
+extension CompListViewController: UISearchResultsUpdating {
+    func updateSearchResults(for searchController: UISearchController) {
+        let query = searchController.searchBar.text ?? ""
+        
+        self.query = query
+        self.filterResult = repository.fetchFilter(query)
+    }
+}
+
+// MARK: - Memo Delegate Protocol
+extension CompListViewController: MemoDelegate {
+    func updateMemo2(title: String, content: String?, dateCreated: Date, _id: ObjectId ) {
+        self.repository.updateMemo2(title: title, content: content, dateCreated: dateCreated, _id: _id)
+    }
+    func updateMemo(memo: Memo) {
+        self.repository.updateMemo(memo)
+    }
+}
+
+extension Results {
+  func toArray() -> [Element] {
+    return compactMap {
+        $0
+    }
+  }
+}

--- a/MemoProject/Presentation/List/CompListViewController.swift
+++ b/MemoProject/Presentation/List/CompListViewController.swift
@@ -212,10 +212,4 @@ extension CompListViewController: MemoDelegate {
     }
 }
 
-extension Results {
-  func toArray() -> [Element] {
-    return compactMap {
-        $0
-    }
-  }
-}
+


### PR DESCRIPTION
##  *PULL REQUEST*

### 🎋 **Working Branch**
- design/#47

### 💡 **Motivation**
 테이블 뷰를 컴포지셔널 레이아웃의 콜렉션뷰로 만들기 

### 🔑 **Key Changes**
- 컴포지셔널 레이아웃을 적용하고 기존 리스트의 테이블뷰를 대체할 새로운 뷰, 뷰컨트롤러를 추가
-  테이블 뷰를 컴포지셔널 레이아웃+DiffableDatasource의 콜렉션뷰로 만들기 
- Results를 배열로 바꾸는 메서드 익스텐션에 추가

🏞 **Screenshots**
|Feature|Screenshot|
|:--:|:--:|
| 콜렉션 뷰로 바꾼 모습  | ![image](https://user-images.githubusercontent.com/51395335/196814259-015f37d2-71db-4ff0-a161-fd9e7f1b2b32.png) |

### Relevant Issue(s)
- #47
